### PR TITLE
Fix make_time denominator sign handling

### DIFF
--- a/src/core/src/time.cpp
+++ b/src/core/src/time.cpp
@@ -7,10 +7,8 @@
 namespace ve {
 
 TimeRational make_time(int64_t num, int32_t den) noexcept {
-    if(den <= 0) den = 1;
-    // Normalize sign to numerator only
-    if(den < 0) { den = -den; num = -num; }
-    return TimeRational{num, den};
+    if(den == 0) den = 1;
+    return normalize(TimeRational{num, den});
 }
 
 Ticks to_ticks(const TimeRational& t) noexcept {

--- a/tests/test_time.cpp
+++ b/tests/test_time.cpp
@@ -7,6 +7,20 @@ TEST_CASE("Time rational to ticks conversion", "[time]") {
     REQUIRE(to_ticks(t) == TICKS_PER_SECOND);
 }
 
+TEST_CASE("Make time handles negative denominator", "[time]") {
+    using namespace ve;
+    auto t = make_time(1, -2);
+    REQUIRE(t.num == -1);
+    REQUIRE(t.den == 2);
+}
+
+TEST_CASE("Make time reduces fractions", "[time]") {
+    using namespace ve;
+    auto t = make_time(2, 4);
+    REQUIRE(t.num == 1);
+    REQUIRE(t.den == 2);
+}
+
 TEST_CASE("Format timecode basic", "[time]") {
     using namespace ve;
     auto t = make_time(48000 * 3661, 48000); // 1h 1m 1s


### PR DESCRIPTION
## Summary
- use normalize in make_time to handle negative denominators and reduce fractions consistently
- add unit test verifying make_time reduces fractions

## Testing
- `cmake -S . -B build` *(fails: unable to access fmt repository: CONNECT tunnel failed, response 403)*
- `ctest --test-dir build` *(no tests were found)*
- `g++ -std=c++17 -I src/core/include src/core/src/time.cpp /tmp/manual_test.cpp -o /tmp/manual_test && /tmp/manual_test`


------
https://chatgpt.com/codex/tasks/task_e_68af59f378e88322ab63ac46ad4caa63